### PR TITLE
infra: 구글 애드센스 사이트 인증 meta 태그 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <meta property="og:description" content="데이터 속 예측력, LSTM과 GPT가 선사하는 비트코인 추세 예측" />
     <meta property="og:image" content="/og_tag.png" />
     <meta property="og:url" content="https://www.flowbit.co.kr/" />
+    <meta name="google-adsense-account" content="ca-pub-3339887235485922">
     <title>플로우빗</title>
   </head>
   <body>


### PR DESCRIPTION
**목적**

- 구글 애드센스 사이트 인증

**작업 내용**

- 구글 애드센스 사이트 인증을 위해 meta 태그 추가했습니다.

**필수 리뷰어**

- @klmhyeonwoo, @Cllaude99 ,@joeunSong

**이슈 번호**

- https://github.com/flowbit-team/flowbit/issues/118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a meta tag to the HTML head section to specify the Google AdSense account ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->